### PR TITLE
Support composing record encoders and decoders

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 // format: off
 
+val catsVersion = "2.9.0"
 val fs2Version = "3.6.1"
 val zioVersion = "2.0.9"
 
@@ -120,6 +121,11 @@ lazy val ceesvee = project.in(file("."))
 
 lazy val core = module("core")
   .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % catsVersion % Optional,
+      "org.typelevel" %% "cats-laws" % catsVersion % Test,
+      "org.typelevel" %% "discipline-munit" % "1.0.9" % Test,
+    ),
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, _)) => Seq(
         "com.softwaremill.magnolia1_2" %% "magnolia" % "1.1.3",
@@ -134,7 +140,7 @@ lazy val fs2 = module("fs2")
   .settings(
     libraryDependencies ++= Seq(
       "co.fs2" %% "fs2-core" % fs2Version,
-      "dev.zio" %% "zio-interop-cats" % "23.0.0.1" % Test,
+      "dev.zio" %% "zio-interop-cats" % "23.0.0.2" % Test,
     ),
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, _)) => Seq(compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full))

--- a/modules/core/src/test/scala/ceesvee/CsvRecordDecoderLaws.scala
+++ b/modules/core/src/test/scala/ceesvee/CsvRecordDecoderLaws.scala
@@ -1,0 +1,85 @@
+package ceesvee
+
+import cats.Eq
+import cats.laws.discipline.ApplyTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+class CsvRecordDecoderLaws extends DisciplineSuite {
+  import CsvRecordDecoderLaws.*
+
+  checkAll(
+    "Apply[CsvRecordDecoder]",
+    ApplyTests[CsvRecordDecoder].apply[A, B, C],
+  )
+}
+
+object CsvRecordDecoderLaws {
+
+  case class A(v: Boolean)
+  object A {
+    implicit val decoder: CsvRecordDecoder[A] = CsvRecordDecoder.derived
+  }
+
+  case class B(v: Int)
+  object B {
+    implicit val decoder: CsvRecordDecoder[B] = CsvRecordDecoder.derived
+  }
+
+  case class C(v: String)
+  object C {
+    implicit val decoder: CsvRecordDecoder[C] = CsvRecordDecoder.derived
+  }
+
+  implicit val arbitraryA: Arbitrary[A] = Arbitrary { Arbitrary.arbBool.arbitrary.map(A(_)) }
+  implicit val arbitraryFA: Arbitrary[CsvRecordDecoder[A]] = Arbitrary { Gen.const(A.decoder) }
+
+  implicit val arbitraryB: Arbitrary[B] = Arbitrary { Arbitrary.arbInt.arbitrary.map(B(_)) }
+  implicit val arbitraryFB: Arbitrary[CsvRecordDecoder[B]] = Arbitrary { Gen.const(B.decoder) }
+
+  implicit val arbitraryC: Arbitrary[C] = Arbitrary { Arbitrary.arbString.arbitrary.map(C(_)) }
+  implicit val arbitraryFC: Arbitrary[CsvRecordDecoder[C]] = Arbitrary { Gen.const(C.decoder) }
+
+  // these instances are bullshit
+  implicit val arbitraryFAB: Arbitrary[CsvRecordDecoder[A => B]] = Arbitrary {
+    val decoder: CsvRecordDecoder[A => B] = new CsvRecordDecoder[A => B] {
+      override val numFields = 0
+      override def decode(fields: IndexedSeq[String]) = Right(a => B(if (a.v) 1 else 0))
+    }
+    Gen.const(decoder)
+  }
+
+  implicit val arbitraryFBC: Arbitrary[CsvRecordDecoder[B => C]] = Arbitrary {
+    val decoder: CsvRecordDecoder[B => C] = new CsvRecordDecoder[B => C] {
+      override val numFields = 0
+      override def decode(fields: IndexedSeq[String]) = Right(b => C(b.v.toString))
+    }
+    Gen.const(decoder)
+  }
+
+  implicit val cogenA: Cogen[A] = Cogen.cogenBoolean.contramap(_.v)
+  implicit val cogenB: Cogen[B] = Cogen.cogenInt.contramap(_.v)
+  implicit val cogenC: Cogen[C] = Cogen.cogenString.contramap(_.v)
+
+  implicit val eqA: Eq[CsvRecordDecoder[A]] = Eq.instance { case (x, y) =>
+    val v = IndexedSeq("true")
+    x.numFields == y.numFields && x.decode(v) == y.decode(v)
+  }
+
+  implicit val eqB: Eq[CsvRecordDecoder[B]] = Eq.instance { case (x, y) =>
+    val v = IndexedSeq("42")
+    x.numFields == y.numFields && x.decode(v) == y.decode(v)
+  }
+
+  implicit val eqC: Eq[CsvRecordDecoder[C]] = Eq.instance { case (x, y) =>
+    val v = IndexedSeq("a string")
+    x.numFields == y.numFields && x.decode(v) == y.decode(v)
+  }
+
+  implicit val eqABC: Eq[CsvRecordDecoder[(A, B, C)]] = Eq.instance { case (x, y) =>
+    val v = IndexedSeq("true", "42", "a string")
+    x.numFields == y.numFields && x.decode(v) == y.decode(v)
+  }
+}

--- a/modules/core/src/test/scala/ceesvee/CsvRecordEncoderLaws.scala
+++ b/modules/core/src/test/scala/ceesvee/CsvRecordEncoderLaws.scala
@@ -1,0 +1,74 @@
+package ceesvee
+
+import cats.Eq
+import cats.laws.discipline.ContravariantSemigroupalTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+class CsvRecordEncoderLaws extends DisciplineSuite {
+  import CsvRecordEncoderLaws.*
+
+  checkAll(
+    "ContravariantSemigroupalTests[CsvRecordEncoder]",
+    ContravariantSemigroupalTests[CsvRecordEncoder].contravariantSemigroupal[A, B, C],
+  )
+}
+
+object CsvRecordEncoderLaws {
+
+  case class A(v: Boolean)
+  object A {
+    val instance = A(true)
+
+    implicit val encoder: CsvRecordEncoder[A] = CsvRecordEncoder.derived
+  }
+
+  case class B(v: Int)
+  object B {
+    val instance = B(42)
+
+    implicit val encoder: CsvRecordEncoder[B] = CsvRecordEncoder.derived
+  }
+
+  case class C(v: String)
+  object C {
+    val instance = C("a string")
+
+    implicit val encoder: CsvRecordEncoder[C] = CsvRecordEncoder.derived
+  }
+
+  implicit val arbitraryA: Arbitrary[A] = Arbitrary { Arbitrary.arbBool.arbitrary.map(A(_)) }
+  implicit val arbitraryFA: Arbitrary[CsvRecordEncoder[A]] = Arbitrary { Gen.const(A.encoder) }
+
+  implicit val arbitraryB: Arbitrary[B] = Arbitrary { Arbitrary.arbInt.arbitrary.map(B(_)) }
+  implicit val arbitraryFB: Arbitrary[CsvRecordEncoder[B]] = Arbitrary { Gen.const(B.encoder) }
+
+  implicit val arbitraryC: Arbitrary[C] = Arbitrary { Arbitrary.arbString.arbitrary.map(C(_)) }
+  implicit val arbitraryFC: Arbitrary[CsvRecordEncoder[C]] = Arbitrary { Gen.const(C.encoder) }
+
+  implicit val cogenA: Cogen[A] = Cogen.cogenBoolean.contramap(_.v)
+  implicit val cogenB: Cogen[B] = Cogen.cogenInt.contramap(_.v)
+  implicit val cogenC: Cogen[C] = Cogen.cogenString.contramap(_.v)
+
+  implicit val eqA: Eq[CsvRecordEncoder[A]] = Eq.instance { case (x, y) =>
+    val v = A.instance
+    x.numFields == y.numFields && x.encode(v) == y.encode(v)
+  }
+
+  implicit val eqB: Eq[CsvRecordEncoder[B]] = Eq.instance { case (x, y) =>
+    val v = B.instance
+    x.numFields == y.numFields && x.encode(v) == y.encode(v)
+  }
+
+  implicit val eqC: Eq[CsvRecordEncoder[C]] = Eq.instance { case (x, y) =>
+    val v = C.instance
+    x.numFields == y.numFields && x.encode(v) == y.encode(v)
+  }
+
+  implicit val eqABC: Eq[CsvRecordEncoder[(A, B, C)]] = Eq.instance { case (x, y) =>
+    val v = (A.instance, B.instance, C.instance)
+    x.numFields == y.numFields && x.encode(v) == y.encode(v)
+  }
+}

--- a/modules/core/src/test/scala/ceesvee/package.scala
+++ b/modules/core/src/test/scala/ceesvee/package.scala
@@ -1,0 +1,11 @@
+package object ceesvee {
+
+  // need to help out Scala 3
+  implicit val invariantE: cats.Invariant[CsvRecordEncoder] =
+    implicitly[cats.ContravariantSemigroupal[CsvRecordEncoder]]
+  implicit val semigroupalE: cats.Semigroupal[CsvRecordEncoder] =
+    implicitly[cats.ContravariantSemigroupal[CsvRecordEncoder]]
+
+  implicit val invariantD: cats.Invariant[CsvRecordDecoder] = implicitly[cats.Apply[CsvRecordDecoder]]
+  implicit val semigroupalD: cats.Semigroupal[CsvRecordDecoder] = implicitly[cats.Apply[CsvRecordDecoder]]
+}


### PR DESCRIPTION
`product` methods have been created for both record encoders and decoders to allow them to be composed. Orphan cats instances are also provided which can be used if cats is a dependency.