### PR TITLE
Optimize Scala 3 derivation

### DIFF
--- a/modules/core/src/main/scala-3/ceesvee/CsvRecordDecoderDeriveScalaVersion.scala
+++ b/modules/core/src/main/scala-3/ceesvee/CsvRecordDecoderDeriveScalaVersion.scala
@@ -7,44 +7,48 @@ import scala.deriving.Mirror
 
 trait CsvRecordDecoderDeriveScalaVersion { self: CsvRecordDecoder.type =>
 
-  inline def summonAll[T <: Tuple]: List[CsvRecordDecoder[?]] = {
-    inline erasedValue[T] match {
-      case _: EmptyTuple => Nil
-      case _: (t *: ts) => summonInline[CsvRecordDecoder[t]] :: summonAll[ts]
-    }
+  inline def summonAll[T <: Tuple]: List[CsvRecordDecoder[?]] = inline erasedValue[T] match {
+    case _: EmptyTuple => Nil
+    case _: (t *: ts) => summonInline[CsvRecordDecoder[t]] :: summonAll[ts]
   }
 
   inline def derived[A](using m: Mirror.ProductOf[A]): CsvRecordDecoder[A] = {
-    lazy val instances = summonAll[m.MirroredElemTypes]
-
-    new CsvRecordDecoder[A] {
-      private val length = instances.length
-
-      override val numFields = instances.foldLeft(0)(_ + _.numFields)
-      override def decode(fields: IndexedSeq[String]) = {
-        decodeUsingInstances(instances, length)(fields).map(values => m.fromProduct(Tuple.fromArray(values)))
-      }
-    }
+    lazy val decoders = summonAll[m.MirroredElemTypes]
+    new CsvRecordDecoderInstance[A](m, decoders)
   }
+}
+
+class CsvRecordDecoderInstance[A](
+  m: Mirror.ProductOf[A],
+  decoders: => List[CsvRecordDecoder[?]],
+) extends CsvRecordDecoder[A] {
+  private lazy val instances = decoders
+  private lazy val length = instances.length
+
+  override lazy val numFields = instances.foldLeft(0)(_ + _.numFields)
 
   @SuppressWarnings(Array(
-    "org.wartremover.warts.AsInstanceOf",
     "org.wartremover.warts.MutableDataStructures",
+    "org.wartremover.warts.Var",
   ))
-  private def decodeUsingInstances[A](instances: List[CsvRecordDecoder[?]], length: Int)(fields: IndexedSeq[String]) = {
-    val errs = SortedMap.newBuilder[Int, Errors.Error]
+  override def decode(fields: IndexedSeq[String]) = {
+    val errs = SortedMap.newBuilder[Int, CsvRecordDecoder.Errors.Error]
     val values = Array.ofDim[Any](length)
 
-    val _ = instances.foldLeft((0, 0)) { case ((index, offset), p) =>
-      val num = p.numFields
-      p.decode(fields.slice(offset, offset + num)) match {
-        case Left(error) => error.errors.foreach { case (k, v) => errs.addOne((k + offset, v)) }
+    var index = 0
+    var offset = 0
+    instances.foreach { decoder =>
+      val num = decoder.numFields
+      decoder.decode(fields.slice(offset, offset + num)) match {
+        case Left(error) => error.errors.foreachEntry { case (k, v) => errs.addOne((k + offset, v)) }
         case Right(v) => values.update(index, v)
       }
-      (index + 1, offset + num)
+      index = index + 1
+      offset = offset + num
     }
 
     val errs_ = errs.result()
-    if (errs_.nonEmpty) Left(Errors(fields, errs_)) else Right(values)
+    if (errs_.nonEmpty) Left(CsvRecordDecoder.Errors(fields, errs_))
+    else Right(m.fromProduct(Tuple.fromArray(values)))
   }
 }

--- a/modules/core/src/main/scala-3/ceesvee/CsvRecordEncoderDeriveScalaVersion.scala
+++ b/modules/core/src/main/scala-3/ceesvee/CsvRecordEncoderDeriveScalaVersion.scala
@@ -6,33 +6,35 @@ import scala.deriving.Mirror
 
 trait CsvRecordEncoderDeriveScalaVersion { self: CsvRecordEncoder.type =>
 
-  inline def summonAll[T <: Tuple]: List[CsvRecordEncoder[?]] = {
-    inline erasedValue[T] match {
-      case _: EmptyTuple => Nil
-      case _: (t *: ts) => summonInline[CsvRecordEncoder[t]] :: summonAll[ts]
-    }
+  inline def summonAll[T <: Tuple]: List[CsvRecordEncoder[?]] = inline erasedValue[T] match {
+    case _: EmptyTuple => Nil
+    case _: (t *: ts) => summonInline[CsvRecordEncoder[t]] :: summonAll[ts]
   }
 
   inline def derived[A](using m: Mirror.ProductOf[A]): CsvRecordEncoder[A] = {
-    lazy val instances = summonAll[m.MirroredElemTypes]
-
-    new CsvRecordEncoder[A] {
-      override val numFields = instances.foldLeft(0)(_ + _.numFields)
-      override def encode(a: A) = encodeUsingInstances(instances, numFields)(a)
-    }
+    lazy val encoders = summonAll[m.MirroredElemTypes]
+    new CsvRecordEncoderInstance(encoders)
   }
+}
 
+class CsvRecordEncoderInstance[A](encoders: => List[CsvRecordEncoder[?]]) extends CsvRecordEncoder[A] {
+  private lazy val instances = encoders
+
+  override lazy val numFields = instances.foldLeft(0)(_ + _.numFields)
   @SuppressWarnings(Array(
     "org.wartremover.warts.AsInstanceOf",
     "org.wartremover.warts.MutableDataStructures",
+    "org.wartremover.warts.Var",
   ))
-  private def encodeUsingInstances[A](instances: List[CsvRecordEncoder[?]], numFields: Int)(a: A) = {
+  override def encode(a: A) = {
     val builder = IndexedSeq.newBuilder[String]
     builder.sizeHint(numFields)
 
-    instances.zipWithIndex.foreach { case (p: CsvRecordEncoder[a], index) =>
+    var index = 0
+    instances.foreach { case (encoder: CsvRecordEncoder[a]) =>
       val v = a.asInstanceOf[Product].productElement(index).asInstanceOf[a]
-      builder.addAll(p.encode(v))
+      builder.addAll(encoder.encode(v))
+      index = index + 1
     }
 
     builder.result()


### PR DESCRIPTION
Avoid making a new instance of an encoder/decoder in the inline derivation methods.

Ensure laziness of summoned encoders/decoders is respected until a method is accessed.