### PR TITLE
Remove supporting \ as a double quote escape

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,13 +186,13 @@ val TestCsvFiles = Map(
   // https://data.gov.uk/dataset/48c917d5-11a0-429f-a0db-0c5ae6ffa1c8/places-to-visit-in-causeway-coast-and-glens
   "uk-causeway-coast-and-glens.csv" -> (
     "https://ccgbcodni-cbcni.opendata.arcgis.com/datasets/42b6ad70a304442dbdb963974d44b433_0.csv",
-    "ad3b923ddd17a8fb774dc60b8ed2f2a8281f2cda",
+    "5a15f2bf5861b34f985da88b33523f18aba10c08",
   ),
 
   // https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads
   "uk-property-sales-price-paid-2019.csv" -> (
     "http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1.amazonaws.com/pp-2019.csv",
-    "f0c8da0dad28e849b78e9cd8f17927d83e0bb14c",
+    "7c9cf6b70599b8ad54365171e5343273a5a91b04",
   ),
 )
 

--- a/modules/core/src/main/scala/ceesvee/CsvParser.scala
+++ b/modules/core/src/main/scala/ceesvee/CsvParser.scala
@@ -93,7 +93,7 @@ object CsvParser {
    * Splits the given strings into CSV lines by splitting on either '\r\n' and
    * '\n'.
    *
-   * Both '"' and '\' are valid escapes for nested double quotes.
+   * '"' is the only valid escape for nested double quotes.
    */
   @throws[Error.LineTooLong]("if a line is longer than `maximumLineLength`")
   @SuppressWarnings(Array(
@@ -169,7 +169,7 @@ object CsvParser {
         val concat = leftover.concat(string)
 
         // assume we have already processed `leftover`,
-        // reprocess the last character in case it was a '\', '"' or '\r'
+        // reprocess the last character in case it was a '"' or '\r'
         var i = (leftover.length - 1).max(0)
         var sliceStart = 0
 
@@ -184,13 +184,6 @@ object CsvParser {
                 if (i < concat.length) {
                   insideQuote = !insideQuote
                 }
-              }
-
-            case '\\' =>
-              if (insideQuote && (i + 1) < concat.length && concat(i + 1) == '"') { // escaped quote
-                i += 2
-              } else {
-                i += 1
               }
 
             case '\n' =>
@@ -266,15 +259,6 @@ object CsvParser {
               } else {
                 i += 1
                 insideQuote = !insideQuote
-              }
-
-            case '\\' =>
-              if (insideQuote && (i + 1) < line.length && line(i + 1) == '"') { // escaped quote
-                val _ = slices += (sliceStart -> i)
-                sliceStart = i + 1
-                i += 2
-              } else {
-                i += 1
               }
 
             case _ =>

--- a/modules/core/src/test/scala/ceesvee/CsvParserSpec.scala
+++ b/modules/core/src/test/scala/ceesvee/CsvParserSpec.scala
@@ -53,10 +53,6 @@ object CsvParserSpec extends ZIOSpecDefault with CsvParserParserSuite {
           val line = """a,"b""c",d,e"f"""
           assertTrue(parseLine[List](line, Options.Defaults) == List("a", """b"c""", "d", "e\"f"))
         },
-        test("slash") {
-          val line = """a,"b\"c",d,e\f"""
-          assertTrue(parseLine[List](line, Options.Defaults) == List("a", """b"c""", "d", "e\\f"))
-        },
       ),
       suite("trim")({
         val line = """abc, def,ghi , jkl , " mno ", """
@@ -82,6 +78,11 @@ object CsvParserSpec extends ZIOSpecDefault with CsvParserParserSuite {
         val line = "abc, def ,,\" g,\"\"h\"\",\ti\" , "
         val result = parseLine[List](line, Options.Defaults)
         assertTrue(result == List("abc", "def", "", " g,\"h\",\ti", ""))
+      },
+      test("json") {
+        val line = """abc,"{""data"": {""message"": ""blah \""quoted\""\n  pos 123""}, ""type"": ""unhandled""}",xyz"""
+        val result = parseLine[List](line, Options.Defaults)
+        assertTrue(result == List("abc", """{"data": {"message": "blah \"quoted\"\n  pos 123"}, "type": "unhandled"}""", "xyz"))
       },
     )
   }

--- a/tests/src/test/scala/ceesvee/tests/RealWorldCsvSpec.scala
+++ b/tests/src/test/scala/ceesvee/tests/RealWorldCsvSpec.scala
@@ -35,8 +35,8 @@ object RealWorldCsvSpec extends ZIOSpecDefault {
       val path = Paths.get(getClass.getResource("/csv/uk-causeway-coast-and-glens.csv").getPath)
 
       val expected = UkCausewayCoast(
-        x = BigDecimal("-6.78939818010469"),
-        y = BigDecimal("55.1552073423335"),
+        x = BigDecimal("677156.193266336"),
+        y = BigDecimal("934878.749389788"),
         name = "Hezlett House",
         address = "107 Sea Road, Castlerock, Co. Londonderry",
         town = "Castlerock",
@@ -84,7 +84,7 @@ object RealWorldCsvSpec extends ZIOSpecDefault {
       assertHeaderTotal("nz-greenhouse-gas-emissions-2019.csv", NZGreenhouseGasEmissions.csvHeader, total)
     }*),
     suite("UK property sales 2019")({
-      val total = 1010985L
+      val total = 1011675L
       assertTotal("uk-property-sales-price-paid-2019.csv", UkPropertySalesPricePaid.decoder, total)
     }*),
   ) @@ TestAspect.timeout(60.seconds) @@ TestAspect.timed


### PR DESCRIPTION
A \ as a double quote escape is not spec compliant.